### PR TITLE
[api]: Make calls sequential as Figma has agressive rate limiting in place now

### DIFF
--- a/src/downloadSvgs.ts
+++ b/src/downloadSvgs.ts
@@ -44,19 +44,18 @@ const getDataFromConfig = async (
   });
 };
 
-const downloadSvgsData = (svgsData: SvgData[]): Promise<DownloadedSvgData[]> =>
-  Promise.all(
-    svgsData.map(
-      async (data): Promise<DownloadedSvgData> => {
-        const downloadedSvg = await fetch(data.url).then(r => r.text());
-
-        return {
-          data: downloadedSvg,
-          name: data.name
-        };
-      }
-    )
-  );
+const downloadSvgsData = async (svgsData: SvgData[]): Promise<DownloadedSvgData[]> => {
+  const batchSize = 100;
+  const downloadedSvgsData: DownloadedSvgData[] = [];
+  for (let i = 0; i < svgsData.length; i += batchSize) {
+    const data = await Promise.all(svgsData.slice(i, i + batchSize).map(svg => fetch(svg.url).then(async r => ({
+      data: await r.text(),
+      name: svg.name
+    }))));
+    downloadedSvgsData.push(...data);
+  }
+  return downloadedSvgsData;
+}
 
 const saveSvgsToFiles = async (
   downloadedSvgsData: DownloadedSvgData[],

--- a/src/getSvgs.ts
+++ b/src/getSvgs.ts
@@ -85,15 +85,16 @@ export default (client: FigmaClient) => async (
 
   const svgsIds = components.map(c => c.id)
   const batchCount = Math.ceil(svgsIds.length / batchSize);
-  const promises = Array.from(Array(batchCount), (_, i) => client.fileImages(config.fileId, {
-    format: "svg",
-    ids: svgsIds.slice(i * batchSize, (i + 1) * batchSize)
-  }))
 
-  const svgsData = (await Promise.all(promises)).flatMap((response, index) => {
-    const svgUrls = response.images;
-    return components.slice(index * batchSize, (index + 1) * batchSize).map(getSvgDataFromImageData(svgUrls))
-  })
+  const svgsData: SvgData[] = [];
+  for (let i = 0; i < batchCount; i++) {
+    const data = await client.fileImages(config.fileId, {
+      format: "svg",
+      ids: svgsIds.slice(i * batchSize, (i + 1) * batchSize)
+    })
+
+    svgsData.push(...components.slice(i * batchSize, (i + 1) * batchSize).map(getSvgDataFromImageData(data.images)))
+  }
 
   return { svgs: svgsData, lastModified: fileLastModified };
 };


### PR DESCRIPTION
Previously we could fetch all the icon batches at once. Unfortunately this is triggering the rate limits now, so we need to back off and wait for retry-after when encountering rate limiting.

Additionally, we now make the requests sequentially to avoid hitting them.